### PR TITLE
Jinja2 Example

### DIFF
--- a/examples/demo.jinja2
+++ b/examples/demo.jinja2
@@ -1,0 +1,1 @@
+Your unique ID is {{ uuid }}

--- a/examples/jinja.py
+++ b/examples/jinja.py
@@ -1,0 +1,39 @@
+"""
+A ContainerComponent demonstrating utilizing a custom loader_class
+for the jinja2 backend. The jinja2 renderer is used to render the
+``demo.jinja2`` template with a new unique identifier each time it
+is rendered.
+
+Any keyword arguments other than those specified by the
+``Jinja2Renderer`` class  are passed directly to the ``__init__``
+method of the ``loader_class``. Please see the `Jinja2 API Docs
+<http://jinja.pocoo.org/docs/dev/api/#loaders>`_ for more detail.
+"""
+
+# Standard library imports
+import asyncio
+from pathlib import Path
+from uuid import uuid1
+
+# Local imports
+from asphalt.core import ContainerComponent, Context, run_application
+from jinja2 import FileSystemLoader
+
+
+class ApplicationComponent(ContainerComponent):
+
+    async def start(self, ctx: Context):
+        """Add a rendering component, then render and print a document"""
+        current_directory = str(Path(__file__).parent)
+        # Note the arguments here will differ depending on your `loader_class`
+        self.add_component('templating', backend='jinja2',
+                           loader_class=FileSystemLoader,
+                           searchpath=current_directory)
+        await super().start(ctx)
+
+        uuid = uuid1()
+        rendered = ctx.jinja2.render('demo.jinja2', uuid=uuid)
+        print(rendered)
+        asyncio.get_event_loop().stop()
+
+run_application(ApplicationComponent())


### PR DESCRIPTION
Provided a functional example component utilizing `jinja2`
in the `examples` directory.

Running this produces the following output:
```
INFO:asphalt.core.runner:Starting application
INFO:asphalt.templating.component:Configured template renderer (default / ctx.jinja2; class=asphalt.templating.renderers.jinja2.Jinja2Renderer)
Your unique ID is 7f63b8dc-85ec-11e6-b237-14109fdd78bb  # changes with every run
INFO:asphalt.core.runner:Application stopped
```

@agronholm please let me know if the module docstring
is too verbose for your taste, and I will cut it down.